### PR TITLE
Implement the `__format__` method using `re.sub`

### DIFF
--- a/src/cooklang_py/base_objects.py
+++ b/src/cooklang_py/base_objects.py
@@ -69,44 +69,21 @@ class BaseObj:
         """
         if not format_spec:
             return str(self)
-        s = ''
-        fs = iter(format_spec)
-        c = next(fs)
-        while True:
-            if c == '%':
-                try:
-                    c = next(fs)
-                except StopIteration:
-                    return s
-                match c:
-                    case 'c':
-                        if self.notes:
-                            s += self.notes
-                    case 'n':
-                        s += self.name
-                    case 'q':
-                        try:
-                            c = next(fs)
-                        except StopIteration:
-                            return s + str(self.quantity)
-                        qformat_spec = ''
-                        if c == '[':
-                            try:
-                                while (c := next(fs)) != ']':
-                                    qformat_spec += c
-                            except StopIteration:
-                                return s + f'{self.quantity:{qformat_spec}}' if self.quantity else ''
-                        s += (f'{self.quantity:{qformat_spec}}' if self.quantity else '') + (c if c != ']' else '')
-                    case _:
-                        s += f'%{c}'
-            else:
-                s += c
-            try:
-                c = next(fs)
-            except StopIteration:
-                return s
-            continue
-        return s
+
+        def expand_format_specifier(match: re.Match[str]) -> str:
+            char = match.group(1)
+            spec = match.group(2)
+            if char == 'c':
+                return self.notes if self.notes else ''
+            if char == 'n':
+                return self.name
+            if char == 'q':
+                if not spec or not self.quantity:
+                    return str(self.quantity)
+                return f'{self.quantity:{spec}}'
+            return match.group(0)
+
+        return re.sub(r'%(.)(?:(?<=[q])\[([^]]*)(?:\]|$))?', expand_format_specifier, format_spec)
 
     @classmethod
     def factory(cls, raw: str):

--- a/src/cooklang_py/quantity.py
+++ b/src/cooklang_py/quantity.py
@@ -66,69 +66,32 @@ class Quantity:
         """
         if not format_spec:
             return str(self)
-        s = ''
-        fs = iter(format_spec)
-        c = next(fs)
-        spaces = 0
-        while True:
-            if c == '%':
+
+        def expand_format_specifier(match: re.Match[str]) -> str:
+            spaces = match.group(1)
+            placeholder = match.group(2)
+
+            if placeholder.startswith('u') and not self.unit:
+                spaces = ''
+
+            if placeholder == 'af':
                 try:
-                    c = next(fs)
-                except StopIteration:
-                    return s
-                match c:
-                    case 'a':
-                        try:
-                            c = next(fs)
-                        except StopIteration:
-                            return s + str(self.amount) if self.amount else ''
-                        match c:
-                            case 'f':
-                                try:
-                                    f = WholeFraction(self.amount) if self.amount else ''
-                                    s += str(f)
-                                    spaces = 0
-                                except ValueError:
-                                    s += str(self.amount if self.amount else '')
-                                    spaces = 0
-                            case '%':
-                                s += str(self.amount if self.amount else '')
-                                spaces = 0
-                                continue
-                            case _:
-                                s += str(self.amount) + c
-                                spaces = 0
-                    case 'u':
-                        try:
-                            c = next(fs)
-                        except StopIteration:
-                            return s + self.unit if self.unit else ''
-                        if not self.unit and spaces:
-                            s = s[: spaces * -1]
-                        match c:
-                            case 's':
-                                s += LONG_TO_SHORT_MAPPINGS.get(self.unit, self.unit if self.unit else '')
-                            case 'l':
-                                s += SHORT_TO_LONG_MAPPINGS.get(self.unit, self.unit if self.unit else '')
-                            case '%':
-                                s += self.unit if self.unit else ''
-                                continue
-                            case _:
-                                s += self.unit if self.unit else '' + c
-                    case _:
-                        s += f'%{c}'
-            else:
-                s += c
-                if c == ' ':
-                    spaces += 1
-                else:
-                    spaces = 0
-            try:
-                c = next(fs)
-            except StopIteration:
-                return s
-            continue
-        return s
+                    f = WholeFraction(self.amount) if self.amount else ''
+                    return spaces + str(f)
+                except ValueError:
+                    return spaces + str(self.amount if self.amount else '')
+            if placeholder == 'a':
+                return spaces + str(self.amount) if self.amount else ''
+            if placeholder == 'ul':
+                return spaces + SHORT_TO_LONG_MAPPINGS.get(self.unit, self.unit if self.unit else '')
+            if placeholder == 'us':
+                return spaces + LONG_TO_SHORT_MAPPINGS.get(self.unit, self.unit if self.unit else '')
+            if placeholder == 'u':
+                return spaces + self.unit if self.unit else ''
+
+            return match.group(0)
+
+        return re.sub(r'( *)%(af|a|ul|us|u)', expand_format_specifier, format_spec)
 
     def __radd__(self, other) -> str:
         if not isinstance(other, str):


### PR DESCRIPTION
This provides a cleaner separation of extracting each format specifier from the logic of actually replacing that format specifier.

Closes #31 