### PR TITLE
Use dynamic prefixes when parsing steps

### DIFF
--- a/src/cooklang_py/recipe.py
+++ b/src/cooklang_py/recipe.py
@@ -159,11 +159,19 @@ class Step:
         if not (section := self._remove_comments(line)):
             return
         self._sections.clear()
-        while match := re.search(r'(?<!\\)[@#~][\S]', section):
+        prefix_pattern = '|'.join(re.escape(prefix) for prefix in sorted(self._prefixes, key=len, reverse=True))
+        if not prefix_pattern:
+            self._sections.append(section)
+            return
+        object_pattern = re.compile(rf'(?<!\\)(?:{prefix_pattern})(?=\S)')
+        while match := object_pattern.search(section):
             if section[: match.start()].strip():
                 self._sections.append(section[: match.start()])
             section = section[match.start() :]
-            obj = self._prefixes[section[0]].factory(section)
+            prefix = match.group()
+            next_match = object_pattern.search(section, len(prefix))
+            raw_section = section[: next_match.start()] if next_match else section
+            obj = self._prefixes[prefix].factory(raw_section)
             self._sections.append(obj)
             section = section.removeprefix(obj.raw)
             match obj:

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from cooklang_py import Cookware, Ingredient, Recipe, Step, Timing
+from cooklang_py import BaseObj, Cookware, Ingredient, Recipe, Step, Timing
 
 
 @pytest.mark.parametrize(
@@ -106,3 +106,19 @@ def test_steps_repr(step):
         "quantity='1.5%qt', notes=None), ', and bake until browned, approximately ', "
         "Timing(raw='~{1%hour}', name='', quantity='1%hour'), '.']"
     )
+
+
+def test_step_uses_custom_prefixes():
+    class Note(BaseObj):
+        prefix = '!'
+        supports_notes = False
+
+    prefixes = {'@': Ingredient, '#': Cookware, '~': Timing, '!': Note}
+
+    step = Step('Mix @flour!important in #bowl', prefixes)
+    sections = list(step)
+
+    assert [type(section) for section in sections] == [str, Ingredient, Note, str, Cookware]
+    assert step.ingredients == [Ingredient('@flour', name='flour')]
+    assert step.cookware == [Cookware('#bowl', name='bowl')]
+    assert sections[2].raw == '!important'


### PR DESCRIPTION
﻿Fixes #39.

`Step` already accepts a `prefixes` mapping, but `_parse` still only looked for `@`, `#`, and `~`. This builds the object matcher from the mapping passed into the step, then uses the same matcher when cutting the current object out of the remaining text. That lets custom prefixes parse as objects instead of being left in the surrounding text or swallowed by the previous object.

Checked locally:

- `python -m pytest tests/test_recipe.py`
- `python -m pytest`
- `python -m ruff check src tests`
- `python -m ruff format --check src tests`
- `python -m compileall src tests`
- `git diff --check`