### PR TITLE
Use dynamic prefixes when parsing steps

### DIFF
--- a/src/cooklang_py/recipe.py
+++ b/src/cooklang_py/recipe.py
@@ -159,7 +159,8 @@ class Step:
         if not (section := self._remove_comments(line)):
             return
         self._sections.clear()
-        while match := re.search(r'(?<!\\)[@#~][\S]', section):
+        prefix_pattern = '|'.join(re.escape(prefix) for prefix in self._prefixes)
+        while match := re.search(rf'(?<!\\)(?:{prefix_pattern})[\S]', section):
             if section[: match.start()].strip():
                 self._sections.append(section[: match.start()])
             section = section[match.start() :]

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from cooklang_py import Cookware, Ingredient, Recipe, Step, Timing
+from cooklang_py import BaseObj, Cookware, Ingredient, Recipe, Step, Timing
 
 
 @pytest.mark.parametrize(
@@ -96,6 +96,26 @@ def test_step_formatted_string_error(step):
     """Test that unrecognized key raises error"""
     with pytest.raises(ValueError):
         step.formatted_string({'unknown': ''})
+
+
+def test_step_uses_custom_prefixes():
+    class Temperature(BaseObj):
+        prefix = '$'
+
+    prefixes = {
+        '@': Ingredient,
+        '#': Cookware,
+        '~': Timing,
+        '$': Temperature,
+    }
+
+    step = Step('Warm $syrup before adding @flour.', prefixes)
+    sections = list(step)
+
+    assert len(sections) == 5
+    assert isinstance(sections[1], Temperature)
+    assert sections[1].name == 'syrup'
+    assert isinstance(sections[3], Ingredient)
 
 
 def test_steps_repr(step):


### PR DESCRIPTION
## Summary
- Build the step object-start regex from the supplied `prefixes` mapping instead of hardcoding `@`, `#`, and `~`.
- Add a regression test for parsing a custom `$`-prefixed object alongside standard ingredients.

Fixes #39.

## Tests
- `uv run pytest -q`
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run python -m compileall src tests`
- `git diff --check`