### PR TITLE
refactor: use divmod in WholeFraction.__str__

### DIFF
--- a/src/cooklang_py/utils.py
+++ b/src/cooklang_py/utils.py
@@ -5,8 +5,8 @@ from fractions import Fraction
 
 class WholeFraction(Fraction):
     def __str__(self):
-        whole = abs(self.numerator) // self.denominator
-        part = abs(self) - whole
+        whole, remainder = divmod(abs(self.numerator), self.denominator)
+        part = Fraction(remainder, self.denominator)
         sign = '-' if self < 0 else ''
         if whole and part:
             return f'{sign}{whole} {part}'


### PR DESCRIPTION
Closes #45

Replaced the manual `numerator // denominator` + `abs(self) - whole` pattern with Python's built-in `divmod()` for cleaner, more idiomatic code. Behavior is identical.